### PR TITLE
Add Docker deployment configuration and Cloud Run instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+dist
+.git
+.gitignore
+Dockerfile
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use an official Node runtime as a parent image for building
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Production image to serve the app
+FROM node:20-alpine AS production
+WORKDIR /app
+RUN npm install -g serve
+
+# Copy built assets from previous stage
+COPY --from=build /app/dist ./dist
+
+# Expose port 8080 for Cloud Run
+EXPOSE 8080
+
+# Run the app with serve
+CMD ["serve", "-s", "dist", "-l", "8080"]

--- a/README.md
+++ b/README.md
@@ -18,3 +18,28 @@ View your app in AI Studio: https://ai.studio/apps/drive/1sYOEqedf3Lbu9w4DXeuTM8
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Deploy to Google Cloud Run
+
+**Prerequisites:** gcloud CLI, Google Cloud project with billing enabled.
+
+1. Build the container image and push it to Google Container Registry:
+   ```sh
+   gcloud builds submit --tag gcr.io/PROJECT_ID/geobar
+   ```
+2. Deploy the container to Cloud Run:
+   ```sh
+   gcloud run deploy geobar \
+     --image gcr.io/PROJECT_ID/geobar \
+     --platform managed \
+     --region REGION \
+     --allow-unauthenticated \
+     --set-env-vars GEMINI_API_KEY=YOUR_GEMINI_KEY
+   ```
+3. Visit the service URL output by the deploy command to use the app.
+
+To test locally with Docker:
+```sh
+docker build -t geobar .
+docker run -p 8080:8080 geobar
+```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview --host 0.0.0.0 --port 8080"
   },
   "dependencies": {
     "react": "^19.1.1",


### PR DESCRIPTION
## Summary
- containerize app with a multi-stage Dockerfile and cleanup via `.dockerignore`
- document Cloud Run deployment steps and local Docker usage
- add `start` script for previewing built app on port 8080

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c094ee18e8832aa3dd57c7a9bffc37